### PR TITLE
Added border color changing support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ Simply install BlueBorder into your plugins folder.
 
 When the plugin is loaded markers will be added to BlueMap for all vanilla world borders.
 
-You can force reload the markers with the `/blueborder` command.
+You can force reload the markers with the `/blueborder refresh` command.
+
+You can configure the world border marker color using `/blueborder color <red> <green> <blue>` or by modifying the generated config file under Plugins > Blueborder

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Displays the vanilla world border in BlueMap.
 
 Builds are available through [Github Actions](https://github.com/pop4959/BlueBorder/actions).
 
+![image](https://github.com/crashbash111/BlueBorder/assets/50429378/7a5462b7-59e8-4d83-a399-f90d43334b72)
+
+
 ## Usage
 
 Simply install BlueBorder into your plugins folder.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "org.popcraft"
-version = "1.1.0"
+version = "1.1.1"
 
 java {
     toolchain {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "org.popcraft"
-version = "1.1.1"
+version = "1.2.0"
 
 java {
     toolchain {

--- a/src/main/java/org/popcraft/blueborder/BlueBorder.java
+++ b/src/main/java/org/popcraft/blueborder/BlueBorder.java
@@ -12,8 +12,11 @@ import org.bukkit.WorldBorder;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,11 +28,22 @@ public final class BlueBorder extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        saveDefaultConfig();
-        config = getConfig();
+        File configFile = new File(getDataFolder(), "config.yml");
+        config = YamlConfiguration.loadConfiguration(configFile);
 
-        //checks config for border color
-        if (config.contains("borderColor.red") && config.contains("borderColor.green") && config.contains("borderColor.blue")){
+        // Create config.yml if it doesn't exist
+        if (!configFile.exists()) {
+            config.set("borderColor.red", borderColor.getRed());
+            config.set("borderColor.green", borderColor.getGreen());
+            config.set("borderColor.blue", borderColor.getBlue());
+            try {
+                config.save(configFile);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        //checks config for border color if exists
+        else if (config.contains("borderColor.red") && config.contains("borderColor.green") && config.contains("borderColor.blue")){
             int red = config.getInt("borderColor.red");
             int green = config.getInt("borderColor.green");
             int blue = config.getInt("borderColor.blue");
@@ -37,7 +51,7 @@ public final class BlueBorder extends JavaPlugin {
                 borderColor = new Color(red, green, blue, 1f);
             }
             else{
-                getServer().getConsoleSender().sendMessage("[" + LABEL + "] Invalid color values in config. Using default color.");
+                getServer().getConsoleSender().sendMessage("[" + this.getName() + "] Invalid color values in config. Using default color.");
                 //assume config invalid, save new file
                 saveBorderColor(borderColor);
             }
@@ -54,9 +68,9 @@ public final class BlueBorder extends JavaPlugin {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if(label.equalsIgnoreCase(MARKER_SET_ID)) {
+        if(label.equalsIgnoreCase(this.getName())) {
             if(args.length == 0) {
-                sender.sendMessage("Usage: /worldborder refresh, /worldborder color <red> <green> <blue>");
+                sender.sendMessage("Usage: /blueborder refresh, /blueborder color <red> <green> <blue>");
                 return false;
             }
             else if(args.length > 0){
@@ -68,7 +82,7 @@ public final class BlueBorder extends JavaPlugin {
                 }
                 else if(args[0].equalsIgnoreCase("color")) {
                     if(args.length != 4) {
-                        sender.sendMessage("Usage: /worldborder color <red> <green> <blue>");
+                        sender.sendMessage("Usage: /blueborder color <red> <green> <blue>");
                         return false;
                     }
                     try {
@@ -93,7 +107,7 @@ public final class BlueBorder extends JavaPlugin {
                 } 
             }
             else {
-                sender.sendMessage("Usage: /worldborder refresh, /worldborder color <red> <green> <blue>");
+                sender.sendMessage("Usage: /blueborder refresh, /blueborder color <red> <green> <blue>");
                 return false;
             }
         }
@@ -104,7 +118,11 @@ public final class BlueBorder extends JavaPlugin {
         config.set("borderColor.red", color.getRed());
         config.set("borderColor.green", color.getGreen());
         config.set("borderColor.blue", color.getBlue());
-        saveConfig();
+        try {
+            config.save(new File(getDataFolder(), "config.yml"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/src/main/java/org/popcraft/blueborder/BlueBorder.java
+++ b/src/main/java/org/popcraft/blueborder/BlueBorder.java
@@ -11,6 +11,7 @@ import org.bukkit.World;
 import org.bukkit.WorldBorder;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Collections;
@@ -19,18 +20,91 @@ import java.util.List;
 public final class BlueBorder extends JavaPlugin {
     private static final String MARKER_SET_ID = "worldborder";
     private static final String LABEL = "World border";
+    private Color borderColor = new Color(0xFF0000, 1f);
+    private FileConfiguration config;
 
     @Override
     public void onEnable() {
+        saveDefaultConfig();
+        config = getConfig();
+
+        //checks config for border color
+        if (config.contains("borderColor.red") && config.contains("borderColor.green") && config.contains("borderColor.blue")){
+            int red = config.getInt("borderColor.red");
+            int green = config.getInt("borderColor.green");
+            int blue = config.getInt("borderColor.blue");
+            if(red >= 0 && red <= 255 && green >= 0 && green <= 255 && blue >= 0 && blue <= 255) {
+                borderColor = new Color(red, green, blue, 1f);
+            }
+            else{
+                getServer().getConsoleSender().sendMessage("[" + LABEL + "] Invalid color values in config. Using default color.");
+                //assume config invalid, save new file
+                saveBorderColor(borderColor);
+            }
+        }
+        else{
+            //assume config invalid, save new file
+            saveBorderColor(borderColor);
+        }
+
+        //refreshes map
         BlueMapAPI.onEnable(this::addWorldBorders);
         BlueMapAPI.onDisable(this::removeWorldBorders);
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        BlueMapAPI.getInstance().ifPresent(this::removeWorldBorders);
-        BlueMapAPI.getInstance().ifPresent(this::addWorldBorders);
+        if(label.equalsIgnoreCase(MARKER_SET_ID)) {
+            if(args.length == 0) {
+                sender.sendMessage("Usage: /worldborder refresh, /worldborder color <red> <green> <blue>");
+                return false;
+            }
+            else if(args.length > 0){
+                if(args[0].equalsIgnoreCase("refresh")) {
+                    BlueMapAPI.getInstance().ifPresent(this::removeWorldBorders);
+                    BlueMapAPI.getInstance().ifPresent(this::addWorldBorders);
+                    sender.sendMessage("World borders refreshed.");
+                    return true;
+                }
+                else if(args[0].equalsIgnoreCase("color")) {
+                    if(args.length != 4) {
+                        sender.sendMessage("Usage: /worldborder color <red> <green> <blue>");
+                        return false;
+                    }
+                    try {
+                        int red = Integer.parseInt(args[1]);
+                        int green = Integer.parseInt(args[2]);
+                        int blue = Integer.parseInt(args[3]);
+                        if(red < 0 || red > 255 || green < 0 || green > 255 || blue < 0 || blue > 255) {
+                            sender.sendMessage("Invalid color values. Must be between 0 and 255.");
+                            return false;
+                        }
+                        borderColor = new Color(red, green, blue, 1f);
+                        BlueMapAPI.getInstance().ifPresent(this::removeWorldBorders);
+                        BlueMapAPI.getInstance().ifPresent(this::addWorldBorders);
+                        sender.sendMessage("World border color changed.");
+                        saveBorderColor(borderColor);
+                        return true;
+                    }
+                    catch(NumberFormatException e) {
+                        sender.sendMessage("Invalid color values. Must be integers.");
+                        return false;
+                    }
+                } 
+            }
+            else {
+                sender.sendMessage("Usage: /worldborder refresh, /worldborder color <red> <green> <blue>");
+                return false;
+            }
+        }
         return true;
+    }
+
+    private void saveBorderColor(Color color) {
+        config.set("borderColor.red", color.getRed());
+        config.set("borderColor.green", color.getGreen());
+        config.set("borderColor.blue", color.getBlue());
+        saveConfig();
     }
 
     @Override
@@ -51,7 +125,7 @@ public final class BlueBorder extends JavaPlugin {
             final ShapeMarker marker = ShapeMarker.builder()
                     .label(LABEL)
                     .shape(border, world.getSeaLevel())
-                    .lineColor(new Color(0xFF0000, 1f))
+                    .lineColor(borderColor)
                     .fillColor(new Color(0))
                     .lineWidth(3)
                     .depthTestEnabled(false)


### PR DESCRIPTION
Added the ability to change the world border color using `/blueborder color <red> <green> <blue>`, or by modifying the newly generated config.yml file in your plugins directory.

Modified the refresh command to require the keyword refresh, e.g., `/blueborder refresh`

Updated version to 1.2.0 to reflect changes.